### PR TITLE
Fix minor typo in the hidden answer of Exercise 8.3.11.

### DIFF
--- a/src/S83.xml
+++ b/src/S83.xml
@@ -516,7 +516,7 @@ Solve the following sets of recurrence relations and initial conditions:</p>
 
 <exercise number="11"><statement><p> <m>S(k) - 4S(k - 1) - 11S(k- 2)+ 30S(k - 3) = 0</m>, 
  <m>S(0) = 0</m>,<m>S(1) = -35,\textrm{  }S(2) = -85</m></p>
-</statement><answer><p> <m>P(k)=4(-3)^k+2^k-5^{k+1}</m></p></answer>
+</statement><answer><p> <m>S(k)=4(-3)^k+2^k-5^{k+1}</m></p></answer>
 </exercise>
 </exercisegroup>
 <exercise number="12"><statement><p>Find a closed form expression for <m>P(k)</m> in Exercise 3 of Section 8.2.</p></statement></exercise>


### PR DESCRIPTION
Specifically, S(k) is used in the exercise but P(k) is given in the answer.