### PR TITLE
Fix typo at S85.xml

### DIFF
--- a/src/S85.xml
+++ b/src/S85.xml
@@ -232,12 +232,12 @@ Keep these figures in mind when we discuss the pop and push operations.</p>
  0 &amp; \textrm{ if } n=0 \\
 \end{array}
 \right.</m></p></li>
-<li><p> <m>((U\downarrow )\uparrow )(n)=(U\downarrow )(n+1)= 2^n= U(n)</m></p></li>
-<li><p> <m>((U\uparrow )\downarrow ) (n)=\left\{
+<li><p> <m>((U\downarrow )\uparrow )(n)=(U\downarrow )(n+1)= \left\{
 \begin{array}{cc}
  0 &amp; \textrm{ if } n = 0 \\
  U(n) &amp; \textrm{ if } n>0 \\
-\end{array}
+\end{array}</m></p></li>
+<li><p> <m>((U\uparrow )\downarrow ) (n)= 2^n= U(n)
 \right.</m></p></li>
 </ol></p></example>
 

--- a/src/S85.xml
+++ b/src/S85.xml
@@ -280,7 +280,7 @@ are generating functions and <m>c</m> is a real number, then the sum <m>G + H</m
 <mdn>
 <mrow xml:id="gf-sum">(G + H)(z)=\sum_{k=0}^{\infty} \left(a_k+b_k\right) z^k</mrow>
 <mrow xml:id="gf-scalarmult">(c G)(z)=\sum_{k=0}^{\infty} c a_k z^k</mrow>
-<mrow xml:id="gf-product">(G H)(z) = \sum_{k=0}^{\infty} c z^k \textrm{ where } c_k= \sum_{j=0}^k a_jb_{k-j}</mrow>
+<mrow xml:id="gf-product">(G H)(z) = \sum_{k=0}^{\infty} c_k z^k \textrm{ where } c_k= \sum_{j=0}^k a_jb_{k-j}</mrow>
 <mrow xml:id="gf-shift">\left(z^p G\right)(z) = z^p\sum_{k=0}^{\infty} a_k z^k=\sum_{k=0}^{\infty} a_k z^{k+p} = \sum_{n=p}^{\infty} a_{n-p} z^n</mrow>
 </mdn>
 </p>


### PR DESCRIPTION
In particular, 
1. there is a missing subscript for $c_k$ in (8.5.11)
2. the end results of l and m in Example 8.5.2 appear to be mistakenly swapped